### PR TITLE
Add share dialog with permission controls

### DIFF
--- a/src/app/contracts/[contractId]/page.tsx
+++ b/src/app/contracts/[contractId]/page.tsx
@@ -31,8 +31,6 @@ import {
   Edit,
   Trash2,
   Copy,
-  Phone,
-  Mail,
   Send,
   PenSquare,
   Clock,
@@ -63,6 +61,9 @@ import type {
   SignatureRequestResponse,
   SignatureRequestResponseSignatures,
 } from '@dropbox/sign'; // Adjust the import path as needed
+import ShareContractDialog from '@/components/contracts/ShareContractDialog';
+import { useContractAccess } from '@/hooks/useContractAccess';
+import type { ContractAccess } from '@shared/types/access-control';
 
 interface AuditLogItem {
   action: string;
@@ -108,7 +109,8 @@ export default function ContractViewPage() {
   const [template, setTemplate] = useState<TemplateSchema | null>(null);
   const [isLoadingContract, setIsLoadingContract] = useState(true);
   const [error, setError] = useState<string | null>(null);
-  const [shareIdentifier, setShareIdentifier] = useState('');
+  const { shareContract, revokeAccess, getAccessList } = useContractAccess();
+  const [accessList, setAccessList] = useState<ContractAccess[]>([]);
   const [isProcessing, setIsProcessing] = useState(false);
   const [signatureRequest, setSignatureRequest] =
     useState<SignatureRequestResponse | null>(null);
@@ -184,6 +186,12 @@ export default function ContractViewPage() {
     }
   }, [contract]);
 
+  useEffect(() => {
+    if (contract) {
+      refreshAccessList();
+    }
+  }, [contract, refreshAccessList]);
+
   const getStatusText = (status?: string): string => {
     switch (status) {
       case 'draft':
@@ -236,79 +244,26 @@ export default function ContractViewPage() {
     }
   };
 
-  const handleShareContract = async () => {
-    if (!contract || !shareIdentifier.trim() || !isOwner) return;
-
-    const normalizedIdentifier = shareIdentifier.trim().toLowerCase();
-    if (
-      (currentUser?.email &&
-        normalizedIdentifier === currentUser.email.toLowerCase()) ||
-      (currentUser?.phoneNumber &&
-        normalizedIdentifier === currentUser.phoneNumber)
-    ) {
-      toast({
-        title: 'שגיאה',
-        description: 'לא ניתן לשתף חוזה עם עצמך.',
-        variant: 'destructive',
-      });
-      return;
-    }
-
-    setIsProcessing(true);
+  const refreshAccessList = useCallback(async () => {
+    if (!contract) return;
     try {
-      const currentSharedWith =
-        contract.sharedWith?.map((s: string) => s.toLowerCase()) || [];
-      if (currentSharedWith.includes(normalizedIdentifier)) {
-        toast({
-          title: 'מידע',
-          description: 'החוזה כבר משותף עם משתמש זה.',
-          variant: 'default',
-        });
-        setShareIdentifier('');
-        setIsProcessing(false);
-        return;
-      }
-      const updatedSharedWith = [
-        ...(contract.sharedWith || []),
-        shareIdentifier.trim(),
-      ];
-      await updateContractData(contract.id, { sharedWith: updatedSharedWith });
-      setContract((prev: Contract | null) =>
-        prev ? { ...prev, sharedWith: updatedSharedWith } : null
-      );
-      toast({
-        title: 'הצלחה',
-        description: `החוזה שותף עם ${shareIdentifier.trim()}.`,
-      });
-      setShareIdentifier('');
+      const list = await getAccessList(contract.id);
+      setAccessList(list);
     } catch (err) {
-      console.error('Error sharing contract:', err);
-      toast({
-        title: 'שגיאה',
-        description: 'שיתוף החוזה נכשל.',
-        variant: 'destructive',
-      });
-    } finally {
-      setIsProcessing(false);
+      console.error('Error loading access list:', err);
     }
-  };
+  }, [contract, getAccessList]);
 
-  const handleRemoveShare = async (identifierToRemove: string) => {
+  const handleRemoveShare = async (access: ContractAccess) => {
     if (!contract || !isOwner) return;
     setIsProcessing(true);
     try {
-      const updatedSharedWith =
-        contract.sharedWith?.filter(
-          (u: string) => u.toLowerCase() !== identifierToRemove.toLowerCase()
-        ) || [];
-      await updateContractData(contract.id, { sharedWith: updatedSharedWith });
-      setContract((prev: Contract | null) =>
-        prev ? { ...prev, sharedWith: updatedSharedWith } : null
-      );
+      await revokeAccess({ contractId: contract.id, userIds: [access.userId] });
       toast({
         title: 'הצלחה',
-        description: `השיתוף עם ${identifierToRemove} הוסר.`,
+        description: `השיתוף עם ${access.email || access.userId} הוסר.`,
       });
+      await refreshAccessList();
     } catch (err) {
       console.error('Error removing share:', err);
       toast({
@@ -822,66 +777,36 @@ export default function ContractViewPage() {
                   </CardTitle>
                 </CardHeader>
                 <CardContent className='space-y-4'>
-                  <div className='space-y-2'>
-                    <Label
-                      htmlFor='share-identifier'
-                      className='text-foreground/80'
-                    >
-                      שתף עם (אימייל או טלפון):
-                    </Label>
-                    <div className='flex gap-2'>
-                      <Input
-                        id='share-identifier'
-                        type='text'
-                        value={shareIdentifier}
-                        onChange={e => setShareIdentifier(e.target.value)}
-                        placeholder='you@example.com או 05X-XXX-XXXX'
-                        className='flex-grow'
-                        disabled={isProcessing}
-                      />
-                      <Button
-                        onClick={handleShareContract}
-                        disabled={isProcessing || !shareIdentifier.trim()}
-                        variant='secondary'
-                      >
-                        {isProcessing ? (
-                          <Loader2 className='animate-spin' />
-                        ) : (
-                          <Share2 />
-                        )}
-                        שתף
-                      </Button>
-                    </div>
-                  </div>
+                  <ShareContractDialog
+                    contractId={contract.id}
+                    onShared={refreshAccessList}
+                  />
                   <div>
                     <h4 className='mb-2 text-sm font-medium text-foreground/80'>
-                      משותף עם:
+                      משתמשים עם גישה:
                     </h4>
-                    {(!contract.sharedWith ||
-                      contract.sharedWith.length === 0) && (
+                    {accessList.length === 0 && (
                       <p className='text-xs text-muted-foreground'>
                         החוזה אינו משותף עם משתמשים אחרים עדיין.
                       </p>
                     )}
                     <ul className='space-y-1 text-sm'>
-                      {contract.sharedWith?.map((identifier: string) => (
+                      {accessList.map(access => (
                         <li
-                          key={identifier}
+                          key={access.id}
                           className='flex items-center justify-between rounded-md bg-muted/30 p-1.5'
                         >
                           <span className='flex items-center text-muted-foreground'>
-                            {identifier.includes('@') ? (
-                              <Mail className='ml-2 h-3 w-3 text-gray-500' />
-                            ) : (
-                              <Phone className='ml-2 h-3 w-3 text-gray-500' />
-                            )}
-                            {identifier}
+                            {access.email || access.userId}
+                            <Badge variant='secondary' className='mr-2'>
+                              {access.accessLevel}
+                            </Badge>
                           </span>
                           <Button
                             variant='ghost'
                             size='icon'
                             className='h-6 w-6'
-                            onClick={() => handleRemoveShare(identifier)}
+                            onClick={() => handleRemoveShare(access)}
                             disabled={isProcessing}
                           >
                             <Trash2 className='h-3 w-3 text-destructive' />

--- a/src/app/contracts/[contractId]/page.tsx
+++ b/src/app/contracts/[contractId]/page.tsx
@@ -186,6 +186,16 @@ export default function ContractViewPage() {
     }
   }, [contract]);
 
+  const refreshAccessList = useCallback(async () => {
+    if (!contract) return;
+    try {
+      const list = await getAccessList(contract.id);
+      setAccessList(list);
+    } catch (err) {
+      console.error('Error loading access list:', err);
+    }
+  }, [contract, getAccessList]);
+
   useEffect(() => {
     if (contract) {
       refreshAccessList();
@@ -243,16 +253,6 @@ export default function ContractViewPage() {
       return 'תאריך לא תקין';
     }
   };
-
-  const refreshAccessList = useCallback(async () => {
-    if (!contract) return;
-    try {
-      const list = await getAccessList(contract.id);
-      setAccessList(list);
-    } catch (err) {
-      console.error('Error loading access list:', err);
-    }
-  }, [contract, getAccessList]);
 
   const handleRemoveShare = async (access: ContractAccess) => {
     if (!contract || !isOwner) return;

--- a/src/components/contracts/ShareContractDialog.tsx
+++ b/src/components/contracts/ShareContractDialog.tsx
@@ -1,0 +1,152 @@
+'use client';
+
+import { useState } from 'react';
+import {
+  Dialog,
+  DialogTrigger,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogDescription,
+  DialogFooter,
+} from '@/components/ui/dialog';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Select, SelectTrigger, SelectValue, SelectContent, SelectItem } from '@/components/ui/select';
+import { Checkbox } from '@/components/ui/checkbox';
+import { Label } from '@/components/ui/label';
+import { Loader2 } from 'lucide-react';
+import { useContractAccess } from '@/hooks/useContractAccess';
+import { useToast } from '@/hooks/use-toast';
+import type { AccessLevel, Permission } from '@shared/types/access-control';
+
+interface ShareContractDialogProps {
+  contractId: string;
+  trigger?: React.ReactNode;
+  onShared?: () => void;
+}
+
+const ACCESS_LEVEL_OPTIONS: AccessLevel[] = [
+  'viewer',
+  'signer',
+  'collaborator',
+];
+
+const PERMISSION_OPTIONS: Permission[] = [
+  'view',
+  'edit',
+  'sign',
+  'download',
+  'manage',
+  'comment',
+  'share',
+  'delete',
+];
+
+export default function ShareContractDialog({
+  contractId,
+  trigger,
+  onShared,
+}: ShareContractDialogProps) {
+  const { shareContract, sharing } = useContractAccess();
+  const { toast } = useToast();
+
+  const [email, setEmail] = useState('');
+  const [accessLevel, setAccessLevel] = useState<AccessLevel>('viewer');
+  const [permissions, setPermissions] = useState<Permission[]>(['view']);
+
+  const togglePermission = (perm: Permission) => {
+    setPermissions(prev =>
+      prev.includes(perm)
+        ? prev.filter(p => p !== perm)
+        : [...prev, perm]
+    );
+  };
+
+  const handleShare = async () => {
+    if (!email.trim()) return;
+    try {
+      await shareContract({
+        contractId,
+        userEmails: [email.trim()],
+        accessLevel,
+        permissions,
+      });
+      toast({ title: 'הצלחה', description: 'החוזה שותף בהצלחה.' });
+      setEmail('');
+      onShared?.();
+    } catch (err: any) {
+      toast({
+        title: 'שגיאה',
+        description: err?.message || 'שיתוף החוזה נכשל.',
+        variant: 'destructive',
+      });
+    }
+  };
+
+  return (
+    <Dialog>
+      <DialogTrigger asChild>{trigger || <Button variant='secondary'>שתף חוזה</Button>}</DialogTrigger>
+      <DialogContent className='sm:max-w-md'>
+        <DialogHeader>
+          <DialogTitle>שתף חוזה</DialogTitle>
+          <DialogDescription>
+            הזן אימייל, בחר רמת גישה וההרשאות.
+          </DialogDescription>
+        </DialogHeader>
+        <div className='space-y-4'>
+          <div className='space-y-2'>
+            <Label htmlFor='share-email'>אימייל</Label>
+            <Input
+              id='share-email'
+              type='email'
+              value={email}
+              onChange={e => setEmail(e.target.value)}
+              placeholder='user@example.com'
+            />
+          </div>
+          <div className='space-y-2'>
+            <Label htmlFor='access-level'>רמת גישה</Label>
+            <Select
+              value={accessLevel}
+              onValueChange={val => setAccessLevel(val as AccessLevel)}
+            >
+              <SelectTrigger id='access-level'>
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                {ACCESS_LEVEL_OPTIONS.map(level => (
+                  <SelectItem key={level} value={level}>
+                    {level}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </div>
+          <div className='space-y-2'>
+            <Label>הרשאות</Label>
+            <div className='grid grid-cols-2 gap-2'>
+              {PERMISSION_OPTIONS.map(p => (
+                <label key={p} className='flex items-center gap-2 text-sm'>
+                  <Checkbox
+                    checked={permissions.includes(p)}
+                    onCheckedChange={() => togglePermission(p)}
+                    id={`perm-${p}`}
+                  />
+                  {p}
+                </label>
+              ))}
+            </div>
+          </div>
+        </div>
+        <DialogFooter className='mt-4'>
+          <Button onClick={handleShare} disabled={sharing || !email.trim()}>
+            {sharing && <Loader2 className='mr-2 h-4 w-4 animate-spin' />}
+            שתף
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}
+


### PR DESCRIPTION
## Summary
- implement `ShareContractDialog` component to choose access level & permissions when sharing contracts
- integrate new dialog on the contract page and show current access list

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688671b85d80833194c2322d38679f2f