### PR TITLE
Add user create hook to link pending contract invites

### DIFF
--- a/docs/development/CONTRACT_ACCESS_REFACTOR_PLAN.md
+++ b/docs/development/CONTRACT_ACCESS_REFACTOR_PLAN.md
@@ -144,6 +144,17 @@ Transform from simple `ownerId` based contract access to a comprehensive access 
 - [x] **Dependencies**: Task 2.5
 - [x] **Completed**: All contract access functions exported from main index
 
+### Task 2.7: Link Pending Invites on User Creation (30 mins)
+
+- [ ] **File**: `/functions/src/contract-access.ts`
+- [ ] **Action**: Trigger function to associate invites when a user registers
+- [ ] **Details**:
+  - Listen to authentication user creation events
+  - Find `contract_access` records where `email` matches the new user and `userId` is empty
+  - Update those records with the user's `uid`
+- [ ] **Test**: Newly registered users immediately see shared contracts
+- [ ] **Dependencies**: Task 2.6
+
 ## Phase 3: Enhanced Backend Services (2-3 hours)
 
 ### Task 3.1: Create Basic Contract Access Service (1 hour) ✅

--- a/functions/src/contract-access.ts
+++ b/functions/src/contract-access.ts
@@ -1,4 +1,5 @@
 import { onCall, HttpsError } from 'firebase-functions/v2/https';
+import { onUserCreated } from 'firebase-functions/v2/identity';
 import { getFirestore, FieldValue } from 'firebase-admin/firestore';
 import { getAuth } from 'firebase-admin/auth';
 import { z } from 'zod';
@@ -557,4 +558,33 @@ export const listContractsWithAccess = onCall(async request => {
       `Failed to list contracts: ${(error as Error).message}`
     );
   }
+});
+
+/**
+ * Associate pending contract invites with newly created users
+ */
+export const linkInvitesOnUserCreate = onUserCreated(async event => {
+  const user = event.data;
+  if (!user?.email) {
+    return;
+  }
+
+  const db = getFirestore();
+
+  const pending = await db
+    .collection('contract_access')
+    .where('email', '==', user.email)
+    .where('userId', '==', '')
+    .get();
+
+  if (pending.empty) {
+    return;
+  }
+
+  const batch = db.batch();
+  pending.docs.forEach(doc => {
+    batch.update(doc.ref, { userId: user.uid });
+  });
+
+  await batch.commit();
 });

--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -527,4 +527,5 @@ export {
   getContractAccessList,
   updateContractAccess,
   listContractsWithAccess,
+  linkInvitesOnUserCreate,
 } from './contract-access';


### PR DESCRIPTION
## Summary
- associate pending contract invites with new users via `linkInvitesOnUserCreate`
- export the new function in the main index
- document this new step in the refactor plan

## Testing
- `npm run lint` *(fails: react/no-unescaped-entities and other eslint errors)*
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68873e62712c83318f8e2227c4beaa77